### PR TITLE
Update architecture.md

### DIFF
--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -3,7 +3,6 @@
 * [Learn more about the CORTX metadata backend](/doc/be/BE_TheMetadataBackend.md)
 * [Powerpoint about CORTX architecture](https://seagatetechnology.sharepoint.com/:p:/s/CORTX/EenbgRuI_SRPtvToqGOc21ABaMxBp7ted6KxOGr_Mja7yQ?e=YzLEtW)
 * [Brainshark about CORTX architecture](https://www.brainshark.com/SeagateCommunications/vu?pi=zGpzSLLI8zROgkz0)
-* [Developer-facing white paper](https://seagatetechnology-my.sharepoint.com/:b:/g/personal/ganesan_umanesan_seagate_com/EXDp-sznHDlHiyLly-0YwzQB0hvZMJ7vhCP88rh0LFJblw?e=2RYstK)
 * [Motr in Prose](/doc/be/motr-in-prose.md)
 * [SNS (io, repair, rebalance)](/doc/be/sns-io-repair-rebalance.md)
 * An [opengrok source code browser](http://ssc-vm-c-192.colo.seagate.com:8090/source/) for our CORTX-S3 code. Currently visible only within Seagate firewall. TODO: migrate to open.


### PR DESCRIPTION
Signed-off-by: John Bent <john.bent@seagate.com>

Removed a redundant link to 'motr in prose' that was internal.