### PR TITLE
Improve Scale-out CORTX on the prerequisites section

### DIFF
--- a/doc/scaleout/Multi_Node_JBOD_Setup.rst
+++ b/doc/scaleout/Multi_Node_JBOD_Setup.rst
@@ -50,7 +50,7 @@ Perform the below mentioned procedure to complete the process of 3 node JBOD Set
       | Private Data network     | connected to another high-speed NIC         |
       +--------------------------+---------------------------------------------+
 	  
-	  +--------------------------+---------------------------------------------+
+      +--------------------------+---------------------------------------------+
       | **Network name/purpose** | **Corresponding NIC**                       |
       +--------------------------+---------------------------------------------+
       | Management network       | connected to the 1 GbE NIC                  |

--- a/doc/scaleout/Multi_Node_JBOD_Setup.rst
+++ b/doc/scaleout/Multi_Node_JBOD_Setup.rst
@@ -52,7 +52,7 @@ Perform the below mentioned procedure to complete the process of 3 node JBOD Set
 	  
       **Note** 
 	  
-	  The Management and Public data networks are required the L3 connectivity from outside. If both of them connect to different VLAN, the IPROUTE2 is required to enabled multiple gateway for the JBODs.
+	The Management and Public data networks are required the L3 connectivity from outside. If both of them connect to different VLAN, the IPROUTE2 is required to enabled multiple gateway for the JBODs.
 	  
 	  Example:
 	   
@@ -127,8 +127,7 @@ Perform the below mentioned procedure to complete the process of 3 node JBOD Set
 				32766:  from all lookup main
 				32767:  from all lookup default
 
-	  After complete this configuration, the both Management and Public data IP Address shoud be accessible from external.
-				
+	  After complete this configuration, the both Management and Public data IP Address shoud be accessible from external.	  
 
 2. Connect the servers to the networks and the JBODs as per the guidelines provided above.
 

--- a/doc/scaleout/Multi_Node_JBOD_Setup.rst
+++ b/doc/scaleout/Multi_Node_JBOD_Setup.rst
@@ -49,6 +49,18 @@ Perform the below mentioned procedure to complete the process of 3 node JBOD Set
       +--------------------------+---------------------------------------------+
       | Private Data network     | connected to another high-speed NIC         |
       +--------------------------+---------------------------------------------+
+	  
+	  +--------------------------+---------------------------------------------+
+      | **Network name/purpose** | **Corresponding NIC**                       |
+      +--------------------------+---------------------------------------------+
+      | Management network       | connected to the 1 GbE NIC                  |
+      +--------------------------+---------------------------------------------+
+      | Public Data network      | connected to the one of the high-speed NICs |
+      +--------------------------+---------------------------------------------+
+      | Private Data network     | connected to another high-speed NIC         |
+      +--------------------------+---------------------------------------------+
+	  
+	  
 
 2. Connect the servers to the networks and the JBODs as per the guidelines provided above.
 

--- a/doc/scaleout/Multi_Node_JBOD_Setup.rst
+++ b/doc/scaleout/Multi_Node_JBOD_Setup.rst
@@ -73,7 +73,6 @@ Perform the below mentioned procedure to complete the process of 3 node JBOD Set
 			GATEWAY=10.0.1.1
 			ZONE=public
 		
-		
 	   Public data network: 
 		- IP: 10.0.2.10/24
 		- Gateway: 10.0.2.1
@@ -129,7 +128,6 @@ Perform the below mentioned procedure to complete the process of 3 node JBOD Set
 				32767:  from all lookup default
 
 	  After complete this configuration, the both Management and Public data IP Address shoud be accessible from external.
-	
 				
 
 2. Connect the servers to the networks and the JBODs as per the guidelines provided above.

--- a/doc/scaleout/Multi_Node_JBOD_Setup.rst
+++ b/doc/scaleout/Multi_Node_JBOD_Setup.rst
@@ -24,6 +24,12 @@ Perform the below mentioned procedure to complete the process of 3 node JBOD Set
 
 **Notes (Server Reference Configuration)**
 
+- Enabled EPEL and SCL repositories
+
+::
+
+  yum -y install epel-release centos-release-scl
+
 - The minimum number of network ports per server is 3.
 
 - Usage of Mellanox HCAs is recommended but not mandatory. For optimal performance you need two high-speed network ports (10 GbE minimum; 50 GbE or 100 GbE recommended). All the three servers must have Mellanox HCA or none of the servers must have it.
@@ -62,6 +68,8 @@ Perform the below mentioned procedure to complete the process of 3 node JBOD Set
 		- Device: eth0
 		- /etc/sysconfig/network-scripts/ifcfg-eth0
 		
+		::
+		
 			TYPE=Ethernet
 			BOOTPROTO=none
 			NAME=eth0
@@ -79,6 +87,8 @@ Perform the below mentioned procedure to complete the process of 3 node JBOD Set
 		- Device: eth1
 		- /etc/sysconfig/network-scripts/ifcfg-eth1
 		
+		::
+		
 			TYPE=Ethernet
 			BOOTPROTO=none
 			NAME=eth1
@@ -92,6 +102,8 @@ Perform the below mentioned procedure to complete the process of 3 node JBOD Set
 		- Please note **NO GATEWAY** directive configured for eth1
 		- The iproute2 configuration:
 			- Append "2		eth1" into /etc/iproute2/rt_tables as below example
+			
+			::
 			
 				#
 				# reserved values
@@ -108,15 +120,22 @@ Perform the below mentioned procedure to complete the process of 3 node JBOD Set
 
 			- Create file /etc/sysconfig/network-scripts/route-eth1 as content below
 			
+			::
+			
 				10.0.2.0/24 dev eth1 src 10.0.2.10 table eth1
 				default via 10.0.2.1 dev eth1 table eth1
 			
 			- Create file /etc/sysconfig/network-scripts/rule-eth1 as content below
 			
+			::
+			
 				from 10.0.2.0/24 table eth1
 				to 10.0.2.0/24 table eth1
   
 			- Restart eth1 interface and verify the configuration
+			
+			::
+			
 				# ifdown eth1; ifup eth1
 				# ip rule
 				0:      from all lookup local

--- a/doc/scaleout/Multi_Node_JBOD_Setup.rst
+++ b/doc/scaleout/Multi_Node_JBOD_Setup.rst
@@ -146,7 +146,7 @@ Perform the below mentioned procedure to complete the process of 3 node JBOD Set
 				32766:  from all lookup main
 				32767:  from all lookup default
 
-	  After complete this configuration, the both Management and Public data IP Address shoud be accessible from external.	  
+	  After complete this configuration, both Management and Public data IP Address shoud be accessible from external.	  
 
 2. Connect the servers to the networks and the JBODs as per the guidelines provided above.
 

--- a/doc/scaleout/Multi_Node_JBOD_Setup.rst
+++ b/doc/scaleout/Multi_Node_JBOD_Setup.rst
@@ -50,17 +50,87 @@ Perform the below mentioned procedure to complete the process of 3 node JBOD Set
       | Private Data network     | connected to another high-speed NIC         |
       +--------------------------+---------------------------------------------+
 	  
-      +--------------------------+---------------------------------------------+
-      | **Network name/purpose** | **Corresponding NIC**                       |
-      +--------------------------+---------------------------------------------+
-      | Management network       | connected to the 1 GbE NIC                  |
-      +--------------------------+---------------------------------------------+
-      | Public Data network      | connected to the one of the high-speed NICs |
-      +--------------------------+---------------------------------------------+
-      | Private Data network     | connected to another high-speed NIC         |
-      +--------------------------+---------------------------------------------+
+      **Note** 
 	  
+	  The Management and Public data networks are required the L3 connectivity from outside. If both of them connect to different VLAN, the IPROUTE2 is required to enabled multiple gateway for the JBODs.
 	  
+	  Example:
+	   
+	   Management network : 
+		- IP: 10.0.1.10/24 
+		- Gateway: 10.0.1.1
+		- Device: eth0
+		- /etc/sysconfig/network-scripts/ifcfg-eth0
+		
+			TYPE=Ethernet
+			BOOTPROTO=none
+			NAME=eth0
+			DEVICE=eth0
+			ONBOOT=yes
+			MTU=9000
+			IPADDR=10.0.1.10
+			PREFIX=24
+			GATEWAY=10.0.1.1
+			ZONE=public
+		
+		
+	   Public data network: 
+		- IP: 10.0.2.10/24
+		- Gateway: 10.0.2.1
+		- Device: eth1
+		- /etc/sysconfig/network-scripts/ifcfg-eth1
+		
+			TYPE=Ethernet
+			BOOTPROTO=none
+			NAME=eth1
+			DEVICE=eth1
+			ONBOOT=yes
+			MTU=9000
+			IPADDR=10.0.2.10
+			PREFIX=24
+			ZONE=public-data-zone
+		
+		- Please note **NO GATEWAY** directive configured for eth1
+		- The iproute2 configuration:
+			- Append "2		eth1" into /etc/iproute2/rt_tables as below example
+			
+				#
+				# reserved values
+				#
+				255     local
+				254     main
+				253     default
+				0       unspec
+				#
+				# local
+				#
+				#1      inr.ruhep
+				2       eth1
+
+			- Create file /etc/sysconfig/network-scripts/route-eth1 as content below
+			
+				10.0.2.0/24 dev eth1 src 10.0.2.10 table eth1
+				default via 10.0.2.1 dev eth1 table eth1
+			
+			- Create file /etc/sysconfig/network-scripts/rule-eth1 as content below
+			
+				from 10.0.2.0/24 table eth1
+				to 10.0.2.0/24 table eth1
+  
+			- Restart eth1 interface and verify the configuration
+				# ifdown eth1; ifup eth1
+				# ip rule
+				0:      from all lookup local
+				32762:  from all to 10.0.2.0/24 lookup eth1
+				32763:  from 10.0.2.0/24 lookup eth1
+				32764:  from all to 10.0.2.0/24 lookup eth1
+				32765:  from 10.0.2.0/24 lookup eth1
+				32766:  from all lookup main
+				32767:  from all lookup default
+
+	  After complete this configuration, the both Management and Public data IP Address shoud be accessible from external.
+	
+				
 
 2. Connect the servers to the networks and the JBODs as per the guidelines provided above.
 


### PR DESCRIPTION

- Enabled EPEL and SCL repositories to avoid an error to install GitPython package
- Sharing the network configuration with multiple VLAN

The Scale-Out 3x Nodes is tested successfully since November 9, 2020