### PR TITLE
Update CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -110,6 +110,7 @@ Thanks for contributing!  If you want to contribute but aren't sure how, please 
 1. [Shashank Parulekar](https://github.com/shashank-parulekar)
 1. [Upendra Patwardhan](https://github.com/upendrapatwardhan)
 1. [Venkataraman Padmanabhan](https://github.com/VenkyOS)
+1. [Venkateswarlu Payidimarry](https://github.com/imvenkip)
 1. [Vinoth Vijayakumar](https://github.com/VinothVijayakumar-dev)
 1. [Yash Bhamare](https://github.com/ydb242)
 


### PR DESCRIPTION
Added Venkateswarlu Payidimarry to the list of names.
Signed-off-by: Venkateswarlu Payidimarry <venkateswarlu.payidimarry@seagate.com>

-----
[View rendered CONTRIBUTORS.md](https://github.com/imvenkip/cortx-1/blob/main/CONTRIBUTORS.md)