### PR TITLE
Update CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -122,6 +122,7 @@ Thanks for contributing!  If you want to contribute but aren't sure how, please 
 1. [Gaurav Gaur](https://github.com/gaurkrgaurav)
 1. [Huang Hua](https://github.com/huanghua78)
 1. [Jaydeep Mohite](https://github.com/jamohite)
+1. [Jugal Patil](https://github.com/JugalPatil)
 1. [John Bent](https://github.com/johnbent)
 1. [Kanchan Chaudhari](https://github.com/kanchan-chaudhari)
 1. [Madhavrao Vemuri](https://github.com/madhavemuri)


### PR DESCRIPTION
Added Jugal Patil to the list of names
Signed-off-by: JugalPatil <jugal.patil@seagate.com>

-----
[View rendered CONTRIBUTORS.md](https://github.com/JugalPatil/cortx/blob/main/CONTRIBUTORS.md)