### PR TITLE
Added link to wiki for running Motr in a cluster

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -11,7 +11,7 @@
     1. Run it on a cluster: [LINK](https://github.com/Seagate/cortx/wiki/Build-Motr-from-Source-in-a-Cluster)
 1. Build motr + S3 from the source: [DONE?](https://github.com/Seagate/cortx-s3server/blob/main/docs/CORTX-S3%20Server%20Quick%20Start%20Guide.md)
     1. Run it on a single node [DONE?](https://github.com/Seagate/cortx-s3server/blob/main/docs/CORTX-S3%20Server%20Quick%20Start%20Guide.md)
-    1. Run it on a cluster [TODO]
+    1. Run it on a cluster [DONE?](https://github.com/Seagate/cortx/wiki/Build-Motr-from-Source-in-a-Cluster)
 1. Build entire CORTX from the source into binaries: [DONE?](https://github.com/Seagate/cortx/blob/main/doc/Release_Build_Creation.rst)
     1. Run it on a single node: TODO 
     1. Run it on a cluster: TODO


### PR DESCRIPTION
Signed-off-by: Patrick Hession <patrick.hession@seagate.com>


### Describe your changes in brief

### Changes
 - Changed TODO to link for building Motr from source and running it in a cluster of nodes

### How Has This Been Tested? (Optional)
 - Tested using VMware Workstation Pro 16 on Windows laptop using iso CentOS 7.8.2003


-----
[View rendered QUICK_START.md](https://github.com/Seagate/cortx/blob/hessio-patch-1/QUICK_START.md)