### PR TITLE
Added Link to run Motr on a cluster

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -8,7 +8,7 @@
     1. Run it across a cluster: [DONE?](doc/scaleout/README.rst)
 1. Build motr from the source: [LINK](https://github.com/Seagate/cortx-motr/blob/main/doc/Quick-Start-Guide.rst)
     1. Run freshly built motr on a single node: [LINK](https://github.com/Seagate/cortx-motr/blob/main/doc/Quick-Start-Guide.rst)
-    1. Run it on a cluster: [DONE?](https://github.com/Seagate/cortx/wiki/Build-Motr-from-Source-in-a-Cluster)
+    1. Run it on a cluster: [LINK](https://github.com/Seagate/cortx/wiki/Build-Motr-from-Source-in-a-Cluster)
 1. Build motr + S3 from the source: [DONE?](https://github.com/Seagate/cortx-s3server/blob/main/docs/CORTX-S3%20Server%20Quick%20Start%20Guide.md)
     1. Run it on a single node [DONE?](https://github.com/Seagate/cortx-s3server/blob/main/docs/CORTX-S3%20Server%20Quick%20Start%20Guide.md)
     1. Run it on a cluster [TODO]


### PR DESCRIPTION
Signed-off-by: Patrick Hession <patrick.hession@seagate.com>

### Describe your changes in brief
- Changed 'DONE?' to LINK for running Motr in a cluster.

### Changes
 - Running Motr in a cluster has now been tested by 2 people.

### How Has This Been Tested? (Optional)
 - @TechWriter-Mayur has tested this using VMWare Workstation Pro
 - I (@hessio) have tested this using Windows Hyper-V 

-----
[View rendered QUICK_START.md](https://github.com/hessio/cortx/blob/patch-5/QUICK_START.md)