### PR TITLE
Updated link to motr in a cluster guide

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -8,7 +8,7 @@
     1. Across a cluster: [DONE?](doc/scaleout/README.rst)
 1. Build motr from the source: [LINK](https://github.com/Seagate/cortx-motr/blob/main/doc/Quick-Start-Guide.rst)
     1. Run it on a single node: [LINK](https://github.com/Seagate/cortx-motr/blob/main/doc/Quick-Start-Guide.rst)
-    1. Run it across a cluster: [LINK](https://github.com/Seagate/cortx/wiki/Build-Motr-from-Source-in-a-Cluster)
+    1. Run it across a cluster: [LINK](https://github.com/Seagate/cortx-motr/wiki/Build-Motr-from-Source-in-a-Cluster)
 1. Build motr + S3 from the source: [DONE?](https://github.com/Seagate/cortx-s3server/blob/main/docs/CORTX-S3%20Server%20Quick%20Start%20Guide.md)
     1. Run it on a single node [DONE?](https://github.com/Seagate/cortx-s3server/blob/main/docs/CORTX-S3%20Server%20Quick%20Start%20Guide.md)
     1. Run it across a cluster [TODO]


### PR DESCRIPTION
Signed-off-by: Patrick Hession <patrick.hession@seagate.com>

### Describe your changes in brief
- Added the correct link to motr in a cluster QSG.

-----
[View rendered QUICK_START.md](https://github.com/hessio/cortx/blob/patch-7/QUICK_START.md)