### PR TITLE
Remove procedure to explicitly open port 28100

### DIFF
--- a/doc/CORTX_on_Open_Virtual_Appliance.rst
+++ b/doc/CORTX_on_Open_Virtual_Appliance.rst
@@ -171,8 +171,6 @@ The procedure to install CORTX on OVA is mentioned below.
                
     salt '*' cmd.run "firewall-cmd --zone=public-data-zone --add-port=80/tcp --permanent"
     
-    salt '*' cmd.run "firewall-cmd --zone=public-data-zone --add-port=28100/tcp --permanent"
-    
     salt '*' cmd.run "firewall-cmd --reload"
       
 Run **ip a l** and record the IP addresses of the following interfaces:


### PR DESCRIPTION
### Describe your changes in brief
The documented step is unnecessary and needs to be removed.

### Changes
 - [ ] This change is required to remove the unnecessary user step to update firewall port config
 - [ ] The port removed is taken care of by Provisioner state for firewall config

### How Has This Been Tested? (Optional)
 - [ ] Tested with OVA.
 - [ ] Removal of unnecessary additional execution step would improve user experience

### Screenshots (if appropriate)

### Checklist
 - [ ] tested locally
 - [ ] added new dependencies
 - [ ] updated the docs
 - [ ] added a test
