### PR TITLE
Added support to check out branches/Git Tags for all CORTX components 

### DIFF
--- a/doc/Release_Build_Creation.rst
+++ b/doc/Release_Build_Creation.rst
@@ -19,6 +19,14 @@ Procedure
    ::
    
     cd /root && git clone https://github.com/Seagate/cortx --recursive --depth=1
+    
+#. Above command will clone codebase from **main** branch by default. You can checkout codebase from other branches for all components using following command. e.g. For **stable** branch,
+   
+   ::
+   
+      docker run --rm -v /var/artifacts:/var/artifacts -v /root/cortx:/cortx-workspace ghcr.io/seagate/cortx-build:centos-7.8.2003 make checkout BRANCH=stable
+      
+   You can also use other Branch name or Tag name instead of **stable** in above command.
    
 #. Create directory to store artifacts. In this procedure, **/var/artifacts** is used. Update **docker run** command accordingly to use an alternative directory.
 


### PR DESCRIPTION
### Describe your changes in brief

### Changes
 - [ ] Why is this change required? What problem does it solve?
        Added support to check out other branches e.g. stable or Release Git Tag in the docker image. 
 - [ ] If proposing a new change then please raise an issue first
### How Has This Been Tested? (Optional)
 - [ ] Please describe in detail how you tested your changes.     
 - [ ] Include details of your testing environment, and the tests you ran to
        Tested by cloning main branch and checkout stable branch using `make checkout BRANCH=stable`. Please find the output below. 
        
```
[root@ssc-vm-1613 cortx]# docker run --rm -v /var/artifacts:/var/artifacts -v /root/cortx:/cortx-workspace ghcr.io/seagate/cortx-build:centos-7.8.2003 make checkout BRANCH=stable
*************** checkout code *********************
pushd cortx-workspace && \
        for component in $(ls -1d cortx-* | grep -Evx 'cortx-experiments||cortx-posix'); do pushd $component; git pull -p --all; git checkout $BRANCH || exit 1; popd ; done  && \
popd || (echo "ERROR: Failed to checkout specified branch/tag Exiting..."; exit 1)
/cortx-workspace /
/cortx-workspace/cortx-ha /cortx-workspace /
Fetching origin
From https://github.com/Seagate/cortx-ha
   63f64ed..be9f9b6  stable     -> origin/stable
Already up-to-date.
Switched to branch 'stable'
Your branch is behind 'origin/stable' by 34 commits, and can be fast-forwarded.
  (use "git pull" to update your local branch)
/cortx-workspace /
/cortx-workspace/cortx-hare /cortx-workspace /
Fetching origin
Already up-to-date.
Switched to branch 'stable'
Your branch is up-to-date with 'origin/stable'.
/cortx-workspace /
/cortx-workspace/cortx-management-portal /cortx-workspace /
Fetching origin
Already up-to-date.
Switched to branch 'stable'
Your branch is up-to-date with 'origin/stable'.
/cortx-workspace /
/cortx-workspace/cortx-manager /cortx-workspace /
Fetching origin
Already up-to-date.
Switched to branch 'stable'
Your branch is up-to-date with 'origin/stable'.
/cortx-workspace /
/cortx-workspace/cortx-monitor /cortx-workspace /
Fetching origin
Already up-to-date.
Switched to branch 'stable'
Your branch is up-to-date with 'origin/stable'.
/cortx-workspace /
/cortx-workspace/cortx-motr /cortx-workspace /
Fetching origin
Already up-to-date.
Switched to branch 'stable'
Your branch is up-to-date with 'origin/stable'.
/cortx-workspace /
/cortx-workspace/cortx-prvsnr /cortx-workspace /
Fetching origin
Already up-to-date.
Switched to branch 'stable'
Your branch is up-to-date with 'origin/stable'.
/cortx-workspace /
/cortx-workspace/cortx-s3server /cortx-workspace /
Fetching origin
Already up-to-date.
Switched to branch 'stable'
Your branch is up-to-date with 'origin/stable'.
/cortx-workspace /
/cortx-workspace/cortx-utils /cortx-workspace /
Fetching origin
From https://github.com/Seagate/cortx-utils
   d6da636..6e079f6  main       -> origin/main
Updating d6da636..6e079f6
Fast-forward
 py-utils/src/setup/msg_bus_test.py | 1 -
 1 file changed, 1 deletion(-)
Switched to branch 'stable'
Your branch is up-to-date with 'origin/stable'.
/cortx-workspace /
/

``` 
To validate branch is checked out properly. 

```
[root@ssc-vm-1613 ~]# cd ~/cortx/cortx-prvsnr/ && git branch && git log -3 --oneline && cd ~/cortx
  dev
  main
* stable
3b11fba FIX: Skip services for data_public  (#1016)
685169b fixes recent regression in cli parser configuration (#1017)
89d04c7 un-skips test and resolves argparse conflict (#1015)
[root@ssc-vm-1613 cortx]#
```
- [ ] How your change affects other areas of the code, etc.

### Screenshots (if appropriate)

### Checklist
 - [x] tested locally
 - [ ] added new dependencies
 - [x] updated the docs
 - [ ] added a test
