### PR TITLE
[Fix for Whitesource CVE-2021-23424] To remove reference to ansi-html

### DIFF
--- a/doc/integrations/euclid/client/package-lock.json
+++ b/doc/integrations/euclid/client/package-lock.json
@@ -1808,7 +1808,6 @@
       "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz",
       "integrity": "sha512-br5Qwvh8D2OQqSXpd1g/xqXKnK0r+Jz6qVKBbWmpUcrbGOxUrf39V5oZ1876084CGn18uMdR5uvPqBv9UqtBjQ==",
       "requires": {
-        "ansi-html": "^0.0.7",
         "error-stack-parser": "^2.0.6",
         "html-entities": "^1.2.1",
         "native-url": "^0.2.6",
@@ -2775,11 +2774,6 @@
           "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
         }
       }
-    },
-    "ansi-html": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
-      "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
     },
     "ansi-regex": {
       "version": "5.0.0",
@@ -16012,7 +16006,6 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.1.tgz",
       "integrity": "sha512-u4R3mRzZkbxQVa+MBWi2uVpB5W59H3ekZAJsQlKUTdl7Elcah2EhygTPLmeFXybQkf9i2+L0kn7ik9SnXa6ihQ==",
       "requires": {
-        "ansi-html": "0.0.7",
         "bonjour": "^3.5.0",
         "chokidar": "^2.1.8",
         "compression": "^1.7.4",

--- a/doc/integrations/myDrive/yarn.lock
+++ b/doc/integrations/myDrive/yarn.lock
@@ -1918,11 +1918,6 @@ ansi-escapes@^4.2.1:
   dependencies:
     type-fest "^0.21.3"
 
-ansi-html@0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
-  integrity sha1-gTWEAhliqenm/QOflA0S9WynhZ4=
-
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -11003,7 +10998,6 @@ webpack-dev-server@^3.10.3:
   resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-3.11.2.tgz#695ebced76a4929f0d5de7fd73fafe185fe33708"
   integrity sha512-A80BkuHRQfCiNtGBS1EMf2ChTUs0x+B3wGDFmOeT4rmJOHhHTCH2naNxIHhmkr0/UillP4U3yeIyv1pNp+QDLQ==
   dependencies:
-    ansi-html "0.0.7"
     bonjour "^3.5.0"
     chokidar "^2.1.8"
     compression "^1.7.4"


### PR DESCRIPTION
### Describe your changes in brief

As part of PR, I am removing reference to ansi-html 0.0.7 version as it is found to be vulnerable.

### Changes
 - [X] Why is this change required? What problem does it solve?

CVSS score of this vulnerability is above 7, so it is tagged as "High" severity,

It makes code vulnerable to DoS attack. If an attacker provides a malicious string, it will get stuck processing the input for an extremely long time, and hence it needs to be addressed,

Also this is a good test, to understand end-to-end process of whitesource scanning and fixes, and this could be a good candidate.
 - [ ] If proposing a new change then please raise an issue first

### How Has This Been Tested? (Optional)
 - [ ] Please describe in detail how you tested your changes.
 - [ ] Include details of your testing environment, and the tests you ran to
 - [ ] How your change affects other areas of the code, etc.

### Screenshots (if appropriate)

### Checklist
 - [ ] tested locally
 - [ ] added new dependencies
 - [ ] updated the docs
 - [ ] added a test


Some questions from reviewer's perspective.

What is impact of this change ?

This change may have impact to webpack-dev-server package, because is is dependent on ansi-html.
However I understand code under "doc" folder is mostly related to documentation, and has no impact over
running code, or functionality.

What testing did we do to ensure, there is no regression / or build breaks due to this change ?

Code changes are in the doc/integration folder and it is not expected to have any impact over
running code, or functionality

However in terms of actual building cortx "doc" locally, I couldn't find any way to do that.

If there is no impact of this library on the running code, or feature , do we need really fix this issue ?

CVSS score of this vulnerability is above 7, so it is tagged as "High" severity, and hence it needs to be addressed,
Also this is a good test, to understand end-to-end process of whitesource scanning and fixes, and this could be a good candidate.

Why are we merging this code to "main" branch?

whitesource scan is triggered only on "main" branch and it is not initiaiting scan on fork, or private branches.
I am checking with whitesource community, if there is a way to initiate a scan on "fork",
But meanwhile, in case if the impact of this change is not very high, I am proposing we merge this change to
"main" branch and check if it addresses vulnerability.

Is it possible that we upgrade ansi-html version to the fixed version, instead of removing dependency completely ?

There is no subsequent (Fixed) version of this package.
https://snyk.io/vuln/SNYK-JS-ANSIHTML-1296849 (Please refer remediation section), also there is no subsequent version of ansi-html here->
https://www.npmjs.com/package/ansi-html.