### PR TITLE
Broken deep link

### DIFF
--- a/doc/integrations/AWS_EC2/README.md
+++ b/doc/integrations/AWS_EC2/README.md
@@ -34,7 +34,7 @@ Step 2: Create security group and subnets
 ------
 - Create a new security group by following [these instructions.](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html#CreatingSecurityGroups) Name this Security Group something recognizable like CORTX SG.
 
-- Once created follow [these instructions](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html#AddRemoveRules) to add the below inbound rules to the security group
+- Once created follow [these instructions](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html#working-with-security-group-rules) to add the below inbound rules to the security group
 
 ![Inbound rules](images/securityGroups.png)
 


### PR DESCRIPTION
Signed-off-by: Harrison Seow <harrison.seow@seagate.com>


### Describe your changes in brief
The previous href tag `#AddRemoveRules` can no longer be found in the web page.
The next closest instruction would be `#working-with-security-group-rules`, which has **Add rules to a security group**.

### Changes
 - [ ] Why is this change required? What problem does it solve?
 - [ ] If proposing a new change then please raise an issue first

### How Has This Been Tested? (Optional)
 - [ ] Please describe in detail how you tested your changes.
 - [ ] Include details of your testing environment, and the tests you ran to
 - [ ] How your change affects other areas of the code, etc.

### Screenshots (if appropriate)

### Checklist
 - [ ] tested locally
 - [ ] added new dependencies
 - [x] updated the docs
 - [ ] added a test
