### PR TITLE
Update QSG link to point to the new default branch in cortx-k8s

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -7,7 +7,7 @@ This document provides quick access to several different ways to set up CORTX fo
     1. On an AWS EC2 instance: [LINK](doc/integrations/AWS_EC2/README.md)
     1. Across a cluster: TODO 
 1. Run CORTX on Kubernetes: [LINK](https://github.com/Seagate/cortx-k8s/blob/integration/README.md)
-    1. Run CORTX on Kubernetes using Amazon Web Services: [LINK](https://github.com/Seagate/cortx-k8s/blob/main/doc/cortx-aws-k8s-installation.md)
+    1. Run CORTX on Kubernetes using Amazon Web Services: [LINK](https://github.com/Seagate/cortx-k8s/blob/integration/doc/cortx-aws-k8s-installation.md)
 1. Build entire CORTX into binaries: [LINK](./doc/community-build/docker/cortx-all/README.md)
 1. Build just the block storage layer (motr) from the source: [LINK](https://github.com/Seagate/cortx-motr/blob/main/doc/Quick-Start-Guide.rst)
     1. Run motr on a single node: [LINK](https://github.com/Seagate/cortx-motr/blob/main/doc/Quick-Start-Guide.rst)


### PR DESCRIPTION
The cortx-k8s repo changed their default branch to `integration`, so new updates will show up there. The updated QSG linked here uses CloudFormation, so this will also resolve #1381 

### Describe your changes in brief

### Changes
 - [ ] Why is this change required? What problem does it solve?
 - [ ] If proposing a new change then please raise an issue first

### How Has This Been Tested? (Optional)
 - [ ] Please describe in detail how you tested your changes.
 - [ ] Include details of your testing environment, and the tests you ran to
 - [ ] How your change affects other areas of the code, etc.

### Screenshots (if appropriate)

### Checklist
 - [ ] tested locally
 - [ ] added new dependencies
 - [ ] updated the docs
 - [ ] added a test


-----
[View rendered QUICK_START.md](https://github.com/trshaffer/cortx/blob/update-k8s-branch/QUICK_START.md)