### PR TITLE
Script to fetch open PRs per given author

### DIFF
--- a/metrics/open_pull_requests.py
+++ b/metrics/open_pull_requests.py
@@ -1,0 +1,47 @@
+import csv
+import sys
+import cortx_community
+
+repo_name = sys.argv[1]
+
+
+# Get repository from given organization
+def get_repo(org_name="seagate"):
+    g = cortx_community.get_gh()
+    org = g.get_organization(org_name)
+    return org.get_repo(repo_name)
+
+
+# Fetch all the open pull requests from the repository
+def get_pulls(orrepo):
+    return orrepo.get_pulls(state='open', sort='created')
+
+
+# Count number of PRs per each author
+def get_pull_author(pulls):
+    users = []
+    for pull in pulls:
+        users.append(pull.user.login)
+    return dict((user, users.count(user)) for user in set(users))
+
+
+# Create a csv file
+def write_to_csv(users, orrepo, total_prs):
+    with open('{}_open_pull_request.csv'.format(orrepo.full_name.split("/")[1]), 'w', newline='') as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=[
+                                "Username", "No_of_open_PRs"])
+        writer.writeheader()
+        for key in users:
+            writer.writerow({"Username": key, "No_of_open_PRs": users[key]})
+        writer.writerow({"Username": "TOTAL_PRs", "No_of_open_PRs":total_prs})
+
+
+def main():
+    orrepo = get_repo()
+    pulls = get_pulls(orrepo)
+    users = get_pull_author(pulls)
+    write_to_csv(users, orrepo, pulls.totalCount)
+
+
+if __name__ == "__main__":
+    main()

--- a/metrics/open_pull_requests.py
+++ b/metrics/open_pull_requests.py
@@ -1,12 +1,10 @@
+import argparse
 import csv
-import sys
 import cortx_community
-
-repo_name = sys.argv[1]
 
 
 # Get repository from given organization
-def get_repo(org_name="seagate"):
+def get_repo(repo_name, org_name="seagate"):
     g = cortx_community.get_gh()
     org = g.get_organization(org_name)
     return org.get_repo(repo_name)
@@ -37,7 +35,11 @@ def write_to_csv(users, orrepo, total_prs):
 
 
 def main():
-    orrepo = get_repo()
+    parser = argparse.ArgumentParser(description='Get repository name')
+    parser.add_argument('--repo_name',  '-i', help='Github repository to fetch open PRs.')
+    args = parser.parse_args()
+
+    orrepo = get_repo(args.repo_name)
     pulls = get_pulls(orrepo)
     users = get_pull_author(pulls)
     write_to_csv(users, orrepo, pulls.totalCount)


### PR DESCRIPTION
### Describe your changes in brief
- The script return a csv file with the number of open PRs per given PR author
- To run the script `python .\metrics\open_pull_requests.py --repo_name {repository name}`
-Example:
`python .\metrics\open_pull_requests.py --repo_name cortx-motr`

### Changes
 - [x] Why is this change required? What problem does it solve?
 Assist in clearing the PR backlog across different repos
 - [ ] If proposing a new change then please raise an issue first

### How Has This Been Tested? (Optional)
 - [ ] Please describe in detail how you tested your changes.
 - [ ] Include details of your testing environment, and the tests you ran to
 - [ ] How your change affects other areas of the code, etc.

### Screenshots (if appropriate)

### Checklist
 - [x] tested locally
 - [ ] added new dependencies
 - [ ] updated the docs
 - [ ] added a test
