### PR TITLE
CORTX-30813: Fixed clone command in community build

### DIFF
--- a/doc/community-build/docker/cortx-all/README.md
+++ b/doc/community-build/docker/cortx-all/README.md
@@ -39,7 +39,7 @@ This document provides step-by-step instructions to build required binaries and 
 
 1. Run the following command to clone the CORTX repository:
     ```
-    cd /mnt && git clone https://github.com/Seagate/cortx --recursive --depth=1 && cd /mnt/cortx && git clone https://github.com/Seagate/cortx-rgw
+    cd /mnt && git clone https://github.com/Seagate/cortx --recursive --depth=1
     ```
     
 2.  Please Checkout **main** branch for generating CORTX packages. Use below command for checkout. 


### PR DESCRIPTION
Signed-off-by: root <root@localhost.localdomain>


### Describe your changes in brief
Fixed clone command as it was returing error as,
`fatal: destination path 'cortx-rgw' already exists and is not an empty directory.`

### Changes
 - [x] Why is this change required? What problem does it solve?
 This problem solves the clone fatal issue
 - [ ] If proposing a new change then please raise an issue first

### How Has This Been Tested? (Optional)
 - [x] Please describe in detail how you tested your changes.
 - [ ] Include details of your testing environment, and the tests you ran to
 - [ ] How your change affects other areas of the code, etc.

### Screenshots (if appropriate)

### Checklist
 - [x] tested locally
 - [ ] added new dependencies
 - [x] updated the docs
 - [ ] added a test


-----
[View rendered doc/community-build/docker/cortx-all/README.md](https://github.com/Seagate/cortx/blob/mukul-CORTX-30813/doc/community-build/docker/cortx-all/README.md)