### PR TITLE
changed to fix issues on Cortx CentOS VM

### DIFF
--- a/doc/integrations/cortx-ftp/README.md
+++ b/doc/integrations/cortx-ftp/README.md
@@ -21,14 +21,14 @@ Note: Dockerfile is available to replace Step 1 and Step 2.
 
 Step 1: Install s3fs
 
-    apt-get install -y s3fs
+    yum install -y s3fs-fuse
 
 
 Step 2: Install ftp server
 
-    apt-get install -y vsftpd
-    sed -i 's/anonymous_enable=NO/anonymous_enable=YES/' /etc/vsftpd.conf
-    mkdir /srv/ftp/cortx-fs
+    yum install -y vsftpd
+    sed -i 's/anonymous_enable=NO/anonymous_enable=YES/' /etc/vsftpd/vsftpd.conf
+    mkdir -p /srv/ftp/cortx-fs
     chmod 600 /srv/ftp/cortx-fs
     service vsftpd start
 
@@ -45,7 +45,7 @@ Step 1: Add some files to the testbucket using tools like Cyberduck or awscli (n
 
 To install awscli.
 
-    apt-get install -y awscli
+    yum install -y awscli
 
 Create aws credential file at ~/.aws/credentials with the following contents.
 


### PR DESCRIPTION
Signed-off-by: Jalen Kan <jalen.j.kan@seagate.com>


### Describe your changes in brief

Fix some command line error for Cortx VM based on CentOS Linux release 7.9.2009 (Core).
1. changed apt-get to yum, as yum is build-in tool in CentOS.
![image](https://user-images.githubusercontent.com/65796721/173175923-c03d7801-c446-453c-92a5-2c5e64d1a37c.png)
3. changed to "install s3fs-fuse" for s3fs as s3f3 only provided by s3fs-fuse
![image](https://user-images.githubusercontent.com/65796721/173175823-10c7ff15-8623-49bb-b55f-bc5578134996.png)
4. changed to fix no such file error for /etc/vsftpd.conf 
![image](https://user-images.githubusercontent.com/65796721/173175869-5c120606-14da-402c-a115-8186f3d2731c.png)

### Changes
 - [ ] Why is this change required? What problem does it solve?
It fixed some command line error on CentOS.
As most Cortx setup document based on CentOS, it's better this doc also works on CentOS.
 - [ ] If proposing a new change then please raise an issue first

### How Has This Been Tested? (Optional)
 - [ ] Please describe in detail how you tested your changes.
 - [ ] Include details of your testing environment, and the tests you ran to
 - [ ] How your change affects other areas of the code, etc.

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/65796721/173175632-fbaf653e-0df8-4caf-a179-baf5d0819467.png)
![image](https://user-images.githubusercontent.com/65796721/173175661-ed8b6bb7-a015-4de5-9a70-6fabc3c5c7c2.png)

### Checklist
 - [ ] tested locally
 - [ ] added new dependencies
 - [ ] updated the docs
 - [ ] added a test
