### PR TITLE
CORTX-32960: Remove cortx-cc submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -40,6 +40,3 @@
 [submodule "cortx-halo"]
 	path = cortx-halo
 	url = https://github.com/Seagate/cortx-halo.git
-[submodule "cortx-cc"]
-	path = cortx-cc
-	url = https://github.com/Seagate/cortx-cc.git


### PR DESCRIPTION
Signed-off-by: Mukul Malhotra <mukul.malhotra@seagate.com>


### Describe your changes in brief
Submodule "cortx-cc" removed to unblock the community and CORTX-32960 as currently the repository is private

### Changes
 - [ ] Why is this change required? What problem does it solve?
 - [ ] If proposing a new change then please raise an issue first

### How Has This Been Tested? (Optional)
 - [x] Please describe in detail how you tested your changes.
 - [ ] Include details of your testing environment, and the tests you ran to
 - [ ] How your change affects other areas of the code, etc.

### Screenshots (if appropriate)

### Checklist
 - [ ] tested locally
 - [ ] added new dependencies
 - [x] updated the docs
 - [ ] added a test
