### PR TITLE
Updated link to join Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Resources
 ---------
 
 <!-- NOTE!!! This is copied from SUPPORT.md.  If you update it here, update it there as well.) -->
--   Converse with us in our CORTX-Open Source Slack channel [![Slack](https://img.shields.io/badge/chat-on%20Slack-blue")](https://cortx.link/slack_invite) to interact with community members and gets your questions answered.
+-   Converse with us in our CORTX-Open Source Slack channel [![Slack](https://img.shields.io/badge/chat-on%20Slack-blue")](https://join.slack.com/t/cortxcommunity/shared_invite/zt-1cnj146n6-GA~0cau4VI1Ojs5UNdf99Q) to interact with community members and gets your questions answered.
 -   Join us in [Discussions](https://github.com/Seagate/cortx/discussions) to ask, answer, and discuss topics with your fellow CORTX contributors.
 -   Check out our [Youtube Channel](https://cortx.link/videos).
 -   Browse a ton of architectural documents in our [Confluence Pages](https://seagate-systems.atlassian.net/wiki/spaces/PUB/overview)


### PR DESCRIPTION
The Slack invite link expired after 30 days so I changed the link to "never expires" and updated the README with the new link

Signed-off-by: hessio <patrick.hession@seagate.com>

Signed-off-by: Patrick Hession <patrick.hession@seagate.com>


### Describe your changes in brief

### Changes
 - [ ] Why is this change required? What problem does it solve?
 - [ ] If proposing a new change then please raise an issue first

### How Has This Been Tested? (Optional)
 - [ ] Please describe in detail how you tested your changes.
 - [ ] Include details of your testing environment, and the tests you ran to
 - [ ] How your change affects other areas of the code, etc.

### Screenshots (if appropriate)

### Checklist
 - [ ] tested locally
 - [ ] added new dependencies
 - [ ] updated the docs
 - [ ] added a test


-----
[View rendered README.md](https://github.com/Seagate/cortx/blob/hessio-patch-1/README.md)