### PR TITLE
changed to improve the code

### DIFF
--- a/doc/integrations/cortx-docker/README.md
+++ b/doc/integrations/cortx-docker/README.md
@@ -27,7 +27,9 @@ Step 1: Install docker.
         gnupg \
         dpkg \
         redhat-lsb-core -y
+    mkdir -p /usr/share/keyrings/
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+    mkdir -p /etc/apt/sources.list.d/
     echo \
       "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
       $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null


### PR DESCRIPTION
Signed-off-by: Jalen Kan <jalen.j.kan@seagate.com>


### Describe your changes in brief
For newly setup OS like Cortx OVA 2.0.0, some required directory like "/usr/share/keyrings/" and "/etc/apt/sources.list.d/" 
not exists to store file "docker-archive-keyring.gpg" and "docker.list".
Improved the code to check & create directory and the whole code block works.

### Changes
 - [ ] Why is this change required? What problem does it solve?
     Improve the code by create required directory before some commands.
 - [ ] If proposing a new change then please raise an issue first

### How Has This Been Tested? (Optional)
 - [ ] Please describe in detail how you tested your changes.
 - [ ] Include details of your testing environment, and the tests you ran to
 - [ ] How your change affects other areas of the code, etc.

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/65796721/181148949-047c94d7-167d-4751-b41c-f3130b363ca2.png)

### Checklist

-  tested locally
 - [ ] added new dependencies
 - [ ] updated the docs
 - [ ] added a test


-----
[View rendered doc/integrations/cortx-docker/README.md](https://github.com/jkan-cn/cortx/blob/jkan-patch6/doc/integrations/cortx-docker/README.md)