### PR TITLE
Fix error in S3 IO operation when download object from S3 bucket

### DIFF
--- a/doc/ova/2.0.0/PI-7/S3_IO_Operations.md
+++ b/doc/ova/2.0.0/PI-7/S3_IO_Operations.md
@@ -61,7 +61,7 @@ aws s3 cp file10Mb s3://mybucket/
 - Validate and download the object from the bucket
 ```bash
 aws s3 ls s3://mybucket/
-aws s3 cp s3://mybucket/ file10Mb-download
+aws s3 cp s3://mybucket/file10Mb file10Mb-download
 ```
 
 - Remove the object from the bucket


### PR DESCRIPTION
Signed-off-by: wb-droid <bo.b.wei@seagate.com>


### Describe your changes in brief
With original command, the object is not downloaded from S3 bucket, and the file10Mb-download is not created, as shown below.

> [root@cortx-ova-rgw ~]# aws s3 cp s3://mybucket/ file10Mb-download                                                      
> [root@cortx-ova-rgw ~]# ls file10Mb-download                                                                            
> ls: cannot access file10Mb-download: No such file or directory

After the fix, the object is downloaded successfully, as shown below.

> [root@cortx-ova-rgw ~]# aws s3 cp s3://mybucket/file10Mb file10Mb-download                                             
> download: s3://mybucket/file10Mb to ./file10Mb-download                                                                
> [root@cortx-ova-rgw ~]# ls file10Mb-download                                                                           
> file10Mb-download
> 



-----
[View rendered doc/ova/2.0.0/PI-7/S3_IO_Operations.md](https://github.com/wb-droid/cortx/blob/s3io/doc/ova/2.0.0/PI-7/S3_IO_Operations.md)